### PR TITLE
Add vs code workspace

### DIFF
--- a/manifest.dnn
+++ b/manifest.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="9.0">
   <packages>
-    <package name="nvisionative.nvQuickTheme-Tailwind" type="Skin" version="1.0.0">
+    <package name="nvisionative.nvQuickTheme-Tailwind" type="Skin" version="1.0.3">
       <friendlyName>nvQuickTheme-Tailwind</friendlyName>
       <description>A DNN Theme Dev Framework based on Tailwind CSS</description>
       <iconFile>MyIcon.png</iconFile>

--- a/menus/NavPrimary/NavPrimary.cshtml
+++ b/menus/NavPrimary/NavPrimary.cshtml
@@ -1,0 +1,183 @@
+@using DotNetNuke.Web.DDRMenu;
+@using System.Dynamic;
+@inherits DotNetNuke.Web.Razor.DotNetNukeWebPage<dynamic>
+
+@functions {
+
+  /*
+    Menu config
+    ===
+    Placed in `@functions` so `@helper` methods can access to these variables.
+    1. If true, add the `.ml-auto` util class to `<ul class="navbar-nav"`>.
+       No class is added if false because left align is default behavior.
+    2. If false, no markup will be generated. Used in `RenderNodes` helper.
+    3. If false, no markup will be generated. Used in `RenderChildren` helper.
+    4. To use a custom SVG icon instead of the Bootstrap default.
+    5. Note that `node.Depth` is 0-based.
+    **************************************************************************/
+  private bool NAV_LAST_IS_ALIGNED_RIGHT = true; // 1 a
+  private bool NAV_ALL_ARE_ALIGNED_RIGHT = false; // 1 b
+  private bool INCLUDE_DROPDOWN_MENUS = true; // 2
+  private bool INCLUDE_NESTED_DROPDOWNS = true; // 3
+  private bool USE_CUSTOM_DROPDOWN_ICON = false; // 4
+  private int MAX_DEPTH_FOR_DROPDOWNS = 1; // 5
+
+  /*
+    Target attributes
+    ===
+    If needed, creates the `target` and `rel` attributes for the `<a>` tag.
+    1. If there is no `node.Target` value, no `target` attribute neccessary.
+    2. Add `rel` with proper values if the link opens in a new window.
+       http://developer.mozilla.org/HTML/Element/a#Security_and_privacy_concerns
+    **************************************************************************/
+  private HtmlString buildTargetAttribute(MenuNode node) {
+    var target = node.Target;
+    var targetString = !String.IsNullOrEmpty(target) ? ("target=\"" + target + "\"") : ""; // 1
+
+    if (target == "_blank") {
+      targetString += " rel=\"noopener noreferrer\""; // 2
+    }
+
+    return new HtmlString(targetString);
+  }
+
+
+  /*
+    Dropdown attributes
+    ===
+    If needed, builds the attributes Bootstrap's dropdown plugin requires.
+    **************************************************************************/
+  private HtmlString buildDropdownAttributes(MenuNode node) {
+    var attributeString = INCLUDE_DROPDOWN_MENUS && node.HasChildren() && (node.Depth <= MAX_DEPTH_FOR_DROPDOWNS) ? ("id=\"tab-" + node.TabId + "-dropdown-toggle\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"") : ""
+    ;
+
+    return new HtmlString(attributeString);
+  }
+}
+
+
+@*
+  Top-level menu
+  ===
+  Builds a Bootstrap `.navbar-nav` component.
+  The pattern for handling CSS classes:
+  - Create lists of strings; initialize with the required classes.
+  - Add classes to the list based on conditions.
+  - Join the list to create the CSS variable used in the markup.
+  Things to note:
+  - The `INCLUDE_DROPDOWN_MENUS` variable is used here.
+  - The `USE_CUSTOM_DROPDOWN_ICON` variable is used here.
+  ****************************************************************************@
+@helper RenderNodes(IList<MenuNode> nodes) {
+  if (nodes.Count > 0) {
+    var navClasses = new List<string> { "flex gap-3 md:flex-row" };
+    if (NAV_LAST_IS_ALIGNED_RIGHT || NAV_ALL_ARE_ALIGNED_RIGHT) {
+      navClasses.Add("ml-auto");
+    }
+    var navCss = String.Join(" ", navClasses);
+    <nav aria-label="Primary">
+      <ul class="@navCss">
+        @foreach (var node in nodes) {
+          var itemClasses = new List<string> { "inline-flex" };
+          var linkClasses = new List<string> { "inline-flex px-4" };
+          var hasDropdown = INCLUDE_DROPDOWN_MENUS && node.HasChildren() 
+            && (node.Depth <= MAX_DEPTH_FOR_DROPDOWNS);
+
+          if (node.Breadcrumb) {
+            itemClasses.Add("active");
+          }
+
+          if (hasDropdown) {
+            itemClasses.Add("group relative");
+            linkClasses.Add("");
+
+            if (USE_CUSTOM_DROPDOWN_ICON) {
+              linkClasses.Add("tw-TBD-dropdown-toggle--custom");
+            }
+          }
+
+          var itemCss = String.Join(" ", itemClasses);
+          var linkCss = String.Join(" ", linkClasses);
+          var linkHref = node.Enabled ? node.Url : "#";
+          var targetAttributes = buildTargetAttribute(node);
+          var dropdownAttributes = buildDropdownAttributes(node);
+
+          <li id="tab-@node.TabId" class="@itemCss">
+            <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>
+              <span>@node.Text</span>
+              @if (hasDropdown && USE_CUSTOM_DROPDOWN_ICON) {
+                <span class="">&downarrow;</span>
+              }
+            </a>
+            @if (INCLUDE_DROPDOWN_MENUS) {
+              @RenderChildren(node)
+            }
+          </li>
+        }
+      </ul>
+    </nav>
+  }
+}
+
+
+@*
+  Dropdown menus
+  ===
+  Builds a Bootstrap `.dropdown-menu` component.
+
+  Things to note:
+  - Similar to `RenderNodes`, but CSS and settings are key differences.
+  - The `INCLUDE_NESTED_DROPDOWN_MENUS` variable is used here.
+  - If using nested dropdowns, this helper recursively calls itself.
+
+  1. If the nav is aligned right and the last node has a dropdown menu,
+     the menu will likely bleed over the edge of the window. This isn't
+     guaranteed to always fix the issue, but it's a starting point.
+  ****************************************************************************@
+@helper RenderChildren(MenuNode node) {
+  var children = node.Children;
+  if (children.Count > 0) {
+    var menuClasses = new List<string> { "absolute top-full left-0 hidden min-w-[200px] flex-col gap-3 rounded-3xl bg-white p-5 py-8 shadow-xl group-hover:flex" };
+    if ((NAV_LAST_IS_ALIGNED_RIGHT && node.Last) || NAV_ALL_ARE_ALIGNED_RIGHT) {
+      menuClasses.Add("tw-TBD-dropdown-menu-right"); // 1
+    }
+    var menuCss = String.Join(" ", menuClasses);
+
+    <ul class="@menuCss" aria-labelledby="tab-@node.TabId-dropdown-toggle">
+      @foreach (var child in children) {
+        var itemClasses = new List<string> {};
+        var linkClasses = new List<string> {};
+
+        if (child.Breadcrumb) {
+          linkClasses.Add("active");
+        }
+
+        if (INCLUDE_NESTED_DROPDOWNS && child.HasChildren() && (node.Depth <= MAX_DEPTH_FOR_DROPDOWNS)) {
+          itemClasses.Add("");
+          linkClasses.Add("");
+        }
+
+        var itemCss = String.Join(" ", itemClasses);
+        var linkCss = String.Join(" ", linkClasses);
+        var linkHref = child.Enabled ? child.Url : "#";
+        var targetAttributes = buildTargetAttribute(child);
+        var dropdownAttributes = INCLUDE_NESTED_DROPDOWNS ? buildDropdownAttributes(child) : null;
+
+        <li id="tab-@child.TabId" class="@itemCss">
+          <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>@child.Text</a>
+          @if (INCLUDE_NESTED_DROPDOWNS) {
+            @RenderChildren(child)
+          }
+        </li>
+      }
+    </ul>
+  }
+}
+
+
+@*
+  Init
+  ===
+  Trigger the magic.
+  ****************************************************************************@
+@RenderNodes(Model.Source.root.Children)

--- a/menus/NavPrimary/README.md
+++ b/menus/NavPrimary/README.md
@@ -1,0 +1,68 @@
+# TODO rewrite after conversion to Tailwind
+
+
+# NavPrimary
+
+This template will generate a DDRMenu with Bootstrap's `.navbar-nav` markup, so it's intended to be used inside a `.navbar` Bootstrap component.
+
+## Directory contents
+
+- `menudef.xml` — The menu manifest.
+- `NavPrimary.cshtml` — The menu template.
+
+_Note: If you change the name of the template file, you must update the manifest, as well._
+
+## What's in the template
+
+### Configuration
+
+Variables that dictate the menu ouput:
+
+| Option                    | Default |
+| ------------------------- | ------: |
+| Align nav to the right?   |    true |
+| Include dropdown menus?   |    true |
+| Include nested dropdowns? |    true |
+| Use custom dropdown icon? |   false |
+
+### Functions
+
+- `buildTargetAttribute` — Adds `target` and `rel` attributes to the link, if needed.
+- `buildDropdownAttributes` — Adds attributes needed for Bootstrap's dropdown plugin.
+
+### Helpers
+
+If you need to modify the CSS classes or HTML in your project's menu, this is where you would do that.
+
+- `RenderNodes` – How the top-level menu is built.
+- `RenderChildren` — How dropdown menus are built.
+
+### MenuNode
+
+These are the menu items. Each node has access to a variety of properties.
+
+#### Properties in use
+
+- `TabId` — Page ID. For unique CSS classes and IDs.
+- `Text` — Page name. The menu link text.
+- `Url` — Page URL.
+- `Target` — Link target.
+- `Enabled` — If enabled, use URL as the `href`. If not, use `#`.
+- `Breadcrumb` — If in breadcrumb, give node an `.active` class.
+- `Children` — How we get dropdown menus.
+- `Last` — Used once to change dropdown menu alignment.
+
+#### Properties not being used
+
+- `Title` — The full page title. **Not being used.**
+- `Selected` — If the page is selected. **Not being used.**
+- `Separator` — If the node is a separator. **Not being used.**
+- `Icon` — The URL of the page icon. **Not being used.**
+- `LargeImage` — The URL of the large page icon. **Not being used.**
+- `First` — If the page is the first in the list. **Not being used.**
+- `Depth` — The depth of the current page. **Not being used.**
+- `Keywords` — Page keywords. **Not being used.**
+- `Description` — Page description. **Not being used.**
+- `Parent` — The parent of the current node. **Not being used.**
+
+For more information, see [the source code](https://github.com/dnnsoftware/Dnn.Platform/blob/development/DNN%20Platform/Modules/DDRMenu/MenuNode.cs#L14) for the `MenuNode` class implementation.

--- a/menus/NavPrimary/menudef.xml
+++ b/menus/NavPrimary/menudef.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<manifest>
+  <template>NavPrimary.cshtml</template>
+</manifest>

--- a/nvQT-Tw.code-workspace
+++ b/nvQT-Tw.code-workspace
@@ -1,7 +1,7 @@
 {
   "folders": [
     {
-      "name": "nvQuickTheme-Tailwind (root)",
+      "name": "nvQT-Tw (root)",
       "path": "."
     },
     {
@@ -28,7 +28,9 @@
           "-noexit",
           "-command",
           "Write-Host 'nvQuickTheme-Tailwind, at deploy using TailwindCss 3.1.x' -ForegroundColor Yellow;",
-          "Write-Host 'Reminder: see the .code-workspace file to update terminal startup commands' -ForegroundColor DarkCyan;",
+          "Write-Host 'Reminders:\r\n - see the .code-workspace file to update this terminal startup output' -ForegroundColor DarkCyan;",
+          "Write-Host ' - Build is   > npm run build' -ForegroundColor DarkCyan;",
+          "Write-Host ' - Package is > npm run package (installable Zip created in /build)' -ForegroundColor DarkCyan;",
           "Write-Host '';",
           "nvm list | % { if($_.Contains('*')) { 'NVM: NodeJS v' + $_.Trim(' *') } } ;",
           "# ls ; # for subsequent commands"

--- a/partials/_header.ascx
+++ b/partials/_header.ascx
@@ -14,9 +14,13 @@
   <div class="bg-light-grey">
     <div class="flex flex-col navbar-header">
       <dnn:LOGO id="dnnLOGO" runat="server" />
-      <nav>
-        <!--dnn:MENU Placeholder-->
-      </nav>
+      <dnn:MENU
+        MenuStyle="menus/NavPrimary"
+        NodeSelector=""
+        IncludeNodes=""
+        ExcludeNodes="" 
+        runat="server"
+      ></dnn:MENU>
     </div>
   </div>
 </header>

--- a/partials/_includes.ascx
+++ b/partials/_includes.ascx
@@ -8,6 +8,10 @@
 <dnn:DnnJsInclude runat="server" FilePath="dist/scripts/custom.min.js" ForceProvider="DnnFormBottomProvider" Priority="120" PathNameAlias="SkinPath" />
 <dnn:DnnJsInclude runat="server" FilePath="dist/scripts/modernizr-custom.min.js" ForceProvider="DnnFormBottomProvider" Priority="130" PathNameAlias="SkinPath" />
 
+<dnn:DnnJsInclude runat="server" FilePath="https://cdn.tailwindcss.com" 
+  ForceProvider="DnnPageHeaderProvider" 
+  HtmlAttributesAsString="async:async,defer:defer" />
+
 <script runat="server">
     protected void Page_Init()
     {

--- a/project-details.json
+++ b/project-details.json
@@ -1,6 +1,6 @@
 {
 	"project": "nvQuickTheme-Tailwind",
-	"version": "1.0.0",
+	"version": "1.0.3",
 	"author": "David Poindexter",
 	"company": "nvisionative",
 	"url": "www.nvquicktheme.com",

--- a/project.code-workspace
+++ b/project.code-workspace
@@ -1,0 +1,50 @@
+{
+  "folders": [
+    {
+      "name": "nvQuickTheme-Tailwind (root)",
+      "path": "."
+    },
+    {
+      "name": "Partials (includes)",
+      "path": "partials"
+    },
+  ],
+  "settings": {
+    "files.associations": {
+      ".eslintrc": "json",
+      ".prettierrc": "json",
+      ".stylelintrc": "json"
+    },
+    "html.format.enable": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false,
+    "terminal.integrated.cwd": "${workspaceFolder}",
+    "terminal.integrated.defaultProfile.windows": "PowerShell",
+    "terminal.integrated.profiles.windows": {
+      "PowerShell": {
+        "path": "pwsh.exe",
+        "args": [
+          "-noexit",
+          "-command",
+          "Write-Host 'nvQuickTheme-Tailwind, at deploy using TailwindCss 3.1.x' -ForegroundColor Yellow;",
+          "Write-Host 'Reminder: see the .code-workspace file to update terminal startup commands' -ForegroundColor DarkCyan;",
+          "Write-Host '';",
+          "nvm list | % { if($_.Contains('*')) { 'NVM: NodeJS v' + $_.Trim(' *') } } ;",
+          "# ls ; # for subsequent commands"
+        ]
+      }
+    },
+    "NOTE": "Using the nvisionative's primary color, #f15922, alpha at 75% (C0) for the title bar, 50% activity, and 25% status",
+    "workbench.colorCustomizations": {
+      "titleBar.activeBackground": "#f15922C0",
+      "activityBar.background": "#f1592280",
+      "statusBar.background": "#f1592240"
+    },
+    "explorer.fileNesting.enabled": true,
+    "explorer.fileNesting.patterns": {
+      "webpack.config.js": "webpack.*.config.js",
+      "*.code-workspace": ".browserslistrc, .eslint*, .*.json, .git*, .editorconfig, .nvmrc, .*ignore, gulp*.js, gulp*.ts, *.config.js, tsconfig.js*"
+    }
+  }
+}


### PR DESCRIPTION
## Experimental diversion 

### to see if we can either contribute to or fork our own version of the project so it is usable in Accuraty's workflow and tech choices

## Description
- added AccuTheme's NavPrimary and did basic conv to Tw (from Bootstrap 4.6)
- added VS Code workspace with startup reminders, colors, etc 

## Still to do
- finish a production quality version of the NavPrimary that allows for all 5+ Accuraty nav/menu variations with docs on usage AND how to change/extend
- add NavSeconary (eyebrow) with full Tw conv and docs
- document any changes we made to nvQT (none? additions only?)
- undo the Tw CDN (hack) used during proof of concept
- adjust versioning back to nvQT-Tw default if this becomes a contribution attempt

## How Has This Been Tested?
- trial by fire... used on 2 Accuraty website projects in Aug/Sep 2022

## Screenshots (next time)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
